### PR TITLE
Hotfix: Null pointer exception when reading outdate config file

### DIFF
--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ModelExportAction.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ModelExportAction.java
@@ -32,30 +32,27 @@ public class ModelExportAction implements VPActionController {
 	 */
 	@Override
 	public void performAction(VPAction action) {
-		final ProjectConfigurations projectConfigurations = Configurations.getInstance().getProjectConfigurations();
 		final Configurations configs = Configurations.getInstance();
+		final ProjectConfigurations projectConfigurations = configs.getProjectConfigurations();
 
 		FileDialog fd = new FileDialog((Frame) ApplicationManager.instance().getViewManager().getRootFrame(),
 				"Choose destination", FileDialog.SAVE);
-		
-		
-		String suggestedFilename;
-		fd.setDirectory(projectConfigurations.getExportFolderPath());
-		
-		if(projectConfigurations.getExportFilename().isEmpty()){
-			String projectName = ApplicationManager.instance().getProjectManager().getProject().getName();		
-			suggestedFilename = projectName+".json";
-			fd.setFile(suggestedFilename);
-		}else{
-			suggestedFilename = projectConfigurations.getExportFilename();
-			fd.setFile(suggestedFilename);
+
+		String suggestedFolderPath = projectConfigurations.getExportFolderPath();
+		String suggestedFileName = projectConfigurations.getExportFilename();
+
+		if(suggestedFileName.isEmpty()){
+			String projectName = ApplicationManager.instance().getProjectManager().getProject().getName();
+			suggestedFileName = projectName+".json";
 		}
-		
+
+		fd.setDirectory(suggestedFolderPath);
+		fd.setFile(suggestedFileName);
 		fd.setVisible(true);
 
 		String fileDirectory = fd.getDirectory();
-
 		String fileName = fd.getFile();
+
 		if(!fileName.endsWith(".json"))
 			fileName+=".json";
 

--- a/src/main/java/it/unibz/inf/ontouml/vp/model/Property.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/model/Property.java
@@ -350,8 +350,6 @@ public class Property implements ModelElement {
 	}
 
 	public void setAggregationKind(String aggregationKind) {
-		System.out.println(aggregationKind);
-
 		if(aggregationKind==null) {
 			this.aggregationKind = null;
 			return;

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/Configurations.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/Configurations.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontouml.vp.utils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.vp.plugin.ApplicationManager;
@@ -60,23 +61,25 @@ public class Configurations {
 			
 			if(configurationsFile.exists()) {
 				String json = "";
-				
 				try {
 					json = new String(Files.readAllBytes(configurationsFile.toPath()));
+					Gson gson = new Gson();
+					instance = gson.fromJson(json, Configurations.class);
 				}
-				catch (IOException e) {
+				catch (Exception e) {
+					if(e instanceof IOException)
+						application.getViewManager().showMessage("Unable to load configuration file (" + OntoUMLPlugin.PLUGIN_NAME + ").\n");
+					else if(e instanceof JsonSyntaxException )
+						application.getViewManager().showMessage("Configuration file ill-formed (" + OntoUMLPlugin.PLUGIN_NAME + ").\n");
+					else
+						application.getViewManager().showMessage("Unknown error while reading configuration file (" + OntoUMLPlugin.PLUGIN_NAME + ").\n");
+
 					e.printStackTrace();
-					application.getViewManager().showMessage("Unable to load " 
-							+ OntoUMLPlugin.PLUGIN_NAME + " configurations.\n" + 
-							"Please contact our team at <https://github.com/OntoUML/ontouml-vp-plugin>.");
 				}
-				
-				Gson gson = new Gson();
-				instance = gson.fromJson(json, Configurations.class);
 			}
-			else {
+
+			if(instance==null)
 				instance = new Configurations();
-			}
 		}
 
 		return instance;

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/ProjectConfigurations.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/ProjectConfigurations.java
@@ -23,7 +23,7 @@ public class ProjectConfigurations {
 
 	@SerializedName("projectId")
 	@Expose()
-	final private String id;
+	private String id;
 	
 	@SerializedName("isOntoUMLPluginEnabled")
 	@Expose()
@@ -31,7 +31,7 @@ public class ProjectConfigurations {
 
 	@SerializedName("serverURL")
 	@Expose()
-	private String serverURL = DEFAULT_SERVER_URL;
+	private String serverURL;
 	
 	@SerializedName("isCustomServerEnabled")
 	@Expose()
@@ -52,7 +52,17 @@ public class ProjectConfigurations {
 	@SerializedName("isAutomaticColoringEnabled")
 	@Expose()
 	private boolean isAutomaticColoringEnabled;
-	
+
+	/**
+	 *
+	 * Constructor without args to be called when deserializing project settings.
+	 *
+	 */
+	public ProjectConfigurations() {
+		this.id = "";
+		this.setDefaultValues();
+	}
+
 	/**
 	 * 
 	 * Initializes an instance of ProjectConfigurations with default settings.
@@ -62,7 +72,7 @@ public class ProjectConfigurations {
 	 */
 	public ProjectConfigurations(String projectId) {
 		this.id = projectId;
-		this.resetDefaults();
+		this.setDefaultValues();
 	}
 	
 	/** 
@@ -71,7 +81,7 @@ public class ProjectConfigurations {
 	 * By default, none of the options are enabled and the server's URL is the plugin's defaults.
 	 * 
 	 */
-	public void resetDefaults() {
+	public void setDefaultValues() {
 		this.isOntoUMLPluginEnabled = ProjectConfigurations.DEFAULT_IS_PLUGIN_ENABLED;
 		
 		this.isCustomServerEnabled = ProjectConfigurations.DEFAULT_IS_CUSTOM_SERVER_ENABLED;


### PR DESCRIPTION
In this PR I treated an exception that is thrown when the project reads a configuration that is   outdated file (missing fields) or corrupted for some reason.

Before this PR, the exception was preventing the export to JSON feature from working.

To test, edit the file .ontouml.config.json that our plugin creates/reads in Visual Paradigms folder.
Try removing fields, adding non-existing fields and breaking JSON's syntax.