### PR TITLE
[Issue23] Disable stereotypes as you model

### DIFF
--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -147,18 +147,17 @@ public class ApplyStereotype implements VPContextActionController {
 			break;
 		}
 
+		boolean isSmartModelingEnabled = Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled();
+
 		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
-
-			if (Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled())
+			if (isSmartModelingEnabled)
 				SmartModelling.setClassMetaProperties((IClass) element);
-			else
-				action.setEnabled(true);
-
-			SmartColoring.paint((IClass) element);
 		}
 
-		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION))
-			SmartModelling.setAssociationMetaProperties((IAssociation) element);
+		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION)) {
+			if (isSmartModelingEnabled)
+				SmartModelling.setAssociationMetaProperties((IAssociation) element);
+		}
 
 		if (Configurations.getInstance().getProjectConfigurations().isAutomaticColoringEnabled())
 			SmartColoring.smartPaint();

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -1,9 +1,6 @@
 package it.unibz.inf.ontouml.vp.controllers;
 
 import java.awt.event.ActionEvent;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import com.vp.plugin.action.VPAction;
 import com.vp.plugin.action.VPContext;
@@ -15,7 +12,6 @@ import com.vp.plugin.model.IStereotype;
 import com.vp.plugin.model.factory.IModelElementFactory;
 
 import it.unibz.inf.ontouml.vp.features.constraints.ActionIds;
-import it.unibz.inf.ontouml.vp.features.constraints.AssociationConstraints;
 import it.unibz.inf.ontouml.vp.utils.SmartColoring;
 import it.unibz.inf.ontouml.vp.utils.SmartModelling;
 import it.unibz.inf.ontouml.vp.utils.StereotypeUtils;
@@ -39,124 +35,124 @@ public class ApplyStereotype implements VPContextActionController {
 		}
 
 		switch (action.getActionId()) {
-			case ActionIds.TYPE:
-				element.addStereotype(StereotypeUtils.STR_TYPE);
-				break;
-			case ActionIds.HISTORICAL_ROLE:
-				element.addStereotype(StereotypeUtils.STR_HISTORICAL_ROLE);
-				break;
-			case ActionIds.EVENT:
-				element.addStereotype(StereotypeUtils.STR_EVENT);
-				break;
-			case ActionIds.ENUMERATION:
-				element.addStereotype(StereotypeUtils.STR_ENUMERATION);
-				break;
-			case ActionIds.DATATYPE:
-				element.addStereotype(StereotypeUtils.STR_DATATYPE);
-				break;
-			case ActionIds.SUBKIND:
-				element.addStereotype(StereotypeUtils.STR_SUBKIND);
-				break;
-			case ActionIds.ROLE_MIXIN:
-				element.addStereotype(StereotypeUtils.STR_ROLE_MIXIN);
-				break;
-			case ActionIds.ROLE:
-				element.addStereotype(StereotypeUtils.STR_ROLE);
-				break;
-			case ActionIds.RELATOR:
-				element.addStereotype(StereotypeUtils.STR_RELATOR);
-				break;
-			case ActionIds.QUANTITY:
-				element.addStereotype(StereotypeUtils.STR_QUANTITY);
-				break;
-			case ActionIds.QUALITY:
-				element.addStereotype(StereotypeUtils.STR_QUALITY);
-				break;
-			case ActionIds.PHASE_MIXIN:
-				element.addStereotype(StereotypeUtils.STR_PHASE_MIXIN);
-				break;
-			case ActionIds.PHASE:
-				element.addStereotype(StereotypeUtils.STR_PHASE);
-				break;
-			case ActionIds.MODE:
-				element.addStereotype(StereotypeUtils.STR_MODE);
-				break;
-			case ActionIds.MIXIN:
-				element.addStereotype(StereotypeUtils.STR_MIXIN);
-				break;
-			case ActionIds.KIND:
-				element.addStereotype(StereotypeUtils.STR_KIND);
-				break;
-			case ActionIds.COLLECTIVE:
-				element.addStereotype(StereotypeUtils.STR_COLLECTIVE);
-				break;
-			case ActionIds.CATEGORY:
-				element.addStereotype(StereotypeUtils.STR_CATEGORY);
-				break;
-			case ActionIds.INSTANTIATION:
-				element.addStereotype(StereotypeUtils.STR_INSTANTIATION);
-				break;
-			case ActionIds.TERMINATION:
-				element.addStereotype(StereotypeUtils.STR_TERMINATION);
-				break;
-			case ActionIds.PARTICIPATIONAL:
-				element.addStereotype(StereotypeUtils.STR_PARTICIPATIONAL);
-				break;
-			case ActionIds.PARTICIPATION:
-				element.addStereotype(StereotypeUtils.STR_PARTICIPATION);
-				break;
-			case ActionIds.HISTORICAL_DEPENDENCE:
-				element.addStereotype(StereotypeUtils.STR_HISTORICAL_DEPENDENCE);
-				break;
-			case ActionIds.CREATION:
-				element.addStereotype(StereotypeUtils.STR_CREATION);
-				break;
-			case ActionIds.MANIFESTATION:
-				element.addStereotype(StereotypeUtils.STR_MANIFESTATION);
-				break;
-			case ActionIds.MATERIAL:
-				element.addStereotype(StereotypeUtils.STR_MATERIAL);
-				break;
-			case ActionIds.COMPARATIVE:
-				element.addStereotype(StereotypeUtils.STR_COMPARATIVE);
-				break;
-			case ActionIds.MEDIATION:
-				element.addStereotype(StereotypeUtils.STR_MEDIATION);
-				break;
-			case ActionIds.CHARACTERIZATION:
-				element.addStereotype(StereotypeUtils.STR_CHARACTERIZATION);
-				break;
-			case ActionIds.EXTERNAL_DEPENDENCE:
-				element.addStereotype(StereotypeUtils.STR_EXTERNAL_DEPENDENCE);
-				break;
-			case ActionIds.COMPONENT_OF:
-				element.addStereotype(StereotypeUtils.STR_COMPONENT_OF);
-				break;
-			case ActionIds.MEMBER_OF:
-				element.addStereotype(StereotypeUtils.STR_MEMBER_OF);
-				break;
-			case ActionIds.SUB_COLLECTION_OF:
-				element.addStereotype(StereotypeUtils.STR_SUB_COLLECTION_OF);
-				break;
-			case ActionIds.SUB_QUANTITY_OF:
-				element.addStereotype(StereotypeUtils.STR_SUB_QUANTITY_OF);
-				break;
-			case ActionIds.BEGIN:
-				element.addStereotype(StereotypeUtils.STR_BEGIN);
-				break;
-			case ActionIds.END:
-				element.addStereotype(StereotypeUtils.STR_END);
-				break;
+		case ActionIds.TYPE:
+			element.addStereotype(StereotypeUtils.STR_TYPE);
+			break;
+		case ActionIds.HISTORICAL_ROLE:
+			element.addStereotype(StereotypeUtils.STR_HISTORICAL_ROLE);
+			break;
+		case ActionIds.EVENT:
+			element.addStereotype(StereotypeUtils.STR_EVENT);
+			break;
+		case ActionIds.ENUMERATION:
+			element.addStereotype(StereotypeUtils.STR_ENUMERATION);
+			break;
+		case ActionIds.DATATYPE:
+			element.addStereotype(StereotypeUtils.STR_DATATYPE);
+			break;
+		case ActionIds.SUBKIND:
+			element.addStereotype(StereotypeUtils.STR_SUBKIND);
+			break;
+		case ActionIds.ROLE_MIXIN:
+			element.addStereotype(StereotypeUtils.STR_ROLE_MIXIN);
+			break;
+		case ActionIds.ROLE:
+			element.addStereotype(StereotypeUtils.STR_ROLE);
+			break;
+		case ActionIds.RELATOR:
+			element.addStereotype(StereotypeUtils.STR_RELATOR);
+			break;
+		case ActionIds.QUANTITY:
+			element.addStereotype(StereotypeUtils.STR_QUANTITY);
+			break;
+		case ActionIds.QUALITY:
+			element.addStereotype(StereotypeUtils.STR_QUALITY);
+			break;
+		case ActionIds.PHASE_MIXIN:
+			element.addStereotype(StereotypeUtils.STR_PHASE_MIXIN);
+			break;
+		case ActionIds.PHASE:
+			element.addStereotype(StereotypeUtils.STR_PHASE);
+			break;
+		case ActionIds.MODE:
+			element.addStereotype(StereotypeUtils.STR_MODE);
+			break;
+		case ActionIds.MIXIN:
+			element.addStereotype(StereotypeUtils.STR_MIXIN);
+			break;
+		case ActionIds.KIND:
+			element.addStereotype(StereotypeUtils.STR_KIND);
+			break;
+		case ActionIds.COLLECTIVE:
+			element.addStereotype(StereotypeUtils.STR_COLLECTIVE);
+			break;
+		case ActionIds.CATEGORY:
+			element.addStereotype(StereotypeUtils.STR_CATEGORY);
+			break;
+		case ActionIds.INSTANTIATION:
+			element.addStereotype(StereotypeUtils.STR_INSTANTIATION);
+			break;
+		case ActionIds.TERMINATION:
+			element.addStereotype(StereotypeUtils.STR_TERMINATION);
+			break;
+		case ActionIds.PARTICIPATIONAL:
+			element.addStereotype(StereotypeUtils.STR_PARTICIPATIONAL);
+			break;
+		case ActionIds.PARTICIPATION:
+			element.addStereotype(StereotypeUtils.STR_PARTICIPATION);
+			break;
+		case ActionIds.HISTORICAL_DEPENDENCE:
+			element.addStereotype(StereotypeUtils.STR_HISTORICAL_DEPENDENCE);
+			break;
+		case ActionIds.CREATION:
+			element.addStereotype(StereotypeUtils.STR_CREATION);
+			break;
+		case ActionIds.MANIFESTATION:
+			element.addStereotype(StereotypeUtils.STR_MANIFESTATION);
+			break;
+		case ActionIds.MATERIAL:
+			element.addStereotype(StereotypeUtils.STR_MATERIAL);
+			break;
+		case ActionIds.COMPARATIVE:
+			element.addStereotype(StereotypeUtils.STR_COMPARATIVE);
+			break;
+		case ActionIds.MEDIATION:
+			element.addStereotype(StereotypeUtils.STR_MEDIATION);
+			break;
+		case ActionIds.CHARACTERIZATION:
+			element.addStereotype(StereotypeUtils.STR_CHARACTERIZATION);
+			break;
+		case ActionIds.EXTERNAL_DEPENDENCE:
+			element.addStereotype(StereotypeUtils.STR_EXTERNAL_DEPENDENCE);
+			break;
+		case ActionIds.COMPONENT_OF:
+			element.addStereotype(StereotypeUtils.STR_COMPONENT_OF);
+			break;
+		case ActionIds.MEMBER_OF:
+			element.addStereotype(StereotypeUtils.STR_MEMBER_OF);
+			break;
+		case ActionIds.SUB_COLLECTION_OF:
+			element.addStereotype(StereotypeUtils.STR_SUB_COLLECTION_OF);
+			break;
+		case ActionIds.SUB_QUANTITY_OF:
+			element.addStereotype(StereotypeUtils.STR_SUB_QUANTITY_OF);
+			break;
+		case ActionIds.BEGIN:
+			element.addStereotype(StereotypeUtils.STR_BEGIN);
+			break;
+		case ActionIds.END:
+			element.addStereotype(StereotypeUtils.STR_END);
+			break;
 		}
-		
-		if(element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)){
+
+		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
 			SmartModelling.setClassMetaProperties((IClass) element);
 			SmartColoring.paint((IClass) element);
 		}
-		
-		if(element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION))
+
+		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION))
 			SmartModelling.setAssociationMetaProperties((IAssociation) element);
-		
+
 		SmartColoring.smartPaint();
 	}
 
@@ -164,45 +160,16 @@ public class ApplyStereotype implements VPContextActionController {
 	public void update(VPAction action, VPContext context) {
 		final IModelElement element = context.getModelElement();
 
-		if (!element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION))
-			return;
-
-		final IAssociation association = (IAssociation) element;
-
-		if (!association.getFrom().getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS))
-			return;
-
-		if (!association.getTo().getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS))
-			return;
-
-		final IClass source = (IClass) association.getFrom();
-		final IClass target = (IClass) association.getTo();
-
-		final ArrayList<String> sourceStereotypes = new ArrayList<String>(Arrays.asList(source.toStereotypeArray()));
-		final ArrayList<String> targetStereotypes = new ArrayList<String>(Arrays.asList(target.toStereotypeArray()));
-
-		if (sourceStereotypes.size() == 0 || targetStereotypes.size() == 0) {
-			// if any end has no stereotypes everything is allowed
-			action.setEnabled(true);
+		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION)) {
+			final IAssociation association = (IAssociation) element;
+			SmartModelling.manageAssociationStereotypes(association, action);
 			return;
 		}
 
-		if (sourceStereotypes.size() > 1 || targetStereotypes.size() > 1) {
-			// if any end has more than 1 stereotypes nothing is allowed
-			action.setEnabled(false);
+		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
+			final IClass _class = (IClass) element;
+			SmartModelling.manageClassStereotypes(_class, action);
 			return;
-		}
-
-		// continue if both ends has ONLY ONE stereotype in both ends
-		final String sourceStereotype = sourceStereotypes.get(0);
-		final String targetStereotype = targetStereotypes.get(0);
-		final ArrayList<String> allowedCombinations = AssociationConstraints.allowedCombinations.get(new SimpleEntry<String, String>(sourceStereotype, targetStereotype));
-
-		if (allowedCombinations == null || !allowedCombinations.contains(action.getActionId())) {
-			action.setEnabled(false);
-		}
-		else {
-			action.setEnabled(true);
 		}
 	}
 

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -166,24 +166,22 @@ public class ApplyStereotype implements VPContextActionController {
 
 	@Override
 	public void update(VPAction action, VPContext context) {
-		final IModelElement element = context.getModelElement();
+		if (Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled()) {
+			final IModelElement element = context.getModelElement();
 
-		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION)) {
-			final IAssociation association = (IAssociation) element;
-			SmartModelling.manageAssociationStereotypes(association, action);
-			return;
-		}
-
-		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
-
-			if (Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled()) {
+			if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION)) {
+				final IAssociation association = (IAssociation) element;
+				SmartModelling.manageAssociationStereotypes(association, action);
+				return;
+			}
+			if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
 				final IClass _class = (IClass) element;
 				SmartModelling.manageClassStereotypes(_class, action);
-			} else {
-				action.setEnabled(true);
+				return;
 			}
-			
-			return;
+		}
+		else {
+			action.setEnabled(true);
 		}
 
 	}

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -12,13 +12,15 @@ import com.vp.plugin.model.IStereotype;
 import com.vp.plugin.model.factory.IModelElementFactory;
 
 import it.unibz.inf.ontouml.vp.features.constraints.ActionIds;
+import it.unibz.inf.ontouml.vp.utils.Configurations;
 import it.unibz.inf.ontouml.vp.utils.SmartColoring;
 import it.unibz.inf.ontouml.vp.utils.SmartModelling;
 import it.unibz.inf.ontouml.vp.utils.StereotypeUtils;
 
 /**
  * 
- * Implementation of context sensitive action of change OntoUML stereotypes in model elements.
+ * Implementation of context sensitive action of change OntoUML stereotypes in
+ * model elements.
  * 
  * @author Claudenir Fonseca
  *
@@ -146,14 +148,20 @@ public class ApplyStereotype implements VPContextActionController {
 		}
 
 		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
-			SmartModelling.setClassMetaProperties((IClass) element);
+
+			if (Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled())
+				SmartModelling.setClassMetaProperties((IClass) element);
+			else
+				action.setEnabled(true);
+
 			SmartColoring.paint((IClass) element);
 		}
 
 		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION))
 			SmartModelling.setAssociationMetaProperties((IAssociation) element);
 
-		SmartColoring.smartPaint();
+		if (Configurations.getInstance().getProjectConfigurations().isAutomaticColoringEnabled())
+			SmartColoring.smartPaint();
 	}
 
 	@Override
@@ -167,10 +175,17 @@ public class ApplyStereotype implements VPContextActionController {
 		}
 
 		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
-			final IClass _class = (IClass) element;
-			SmartModelling.manageClassStereotypes(_class, action);
+
+			if (Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled()) {
+				final IClass _class = (IClass) element;
+				SmartModelling.manageClassStereotypes(_class, action);
+			} else {
+				action.setEnabled(true);
+			}
+			
 			return;
 		}
+
 	}
 
 }

--- a/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ClassConstraints.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ClassConstraints.java
@@ -1,0 +1,59 @@
+package it.unibz.inf.ontouml.vp.features.constraints;
+
+import it.unibz.inf.ontouml.vp.utils.StereotypeUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClassConstraints {
+
+	@SuppressWarnings("serial")
+	public static final Map<String, ArrayList<String>> allowedSubCombinations = new HashMap<String, ArrayList<String>>() {
+		{
+			put(StereotypeUtils.STR_KIND, new ArrayList<>(Arrays.asList(ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_QUANTITY, new ArrayList<>(Arrays.asList(ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_COLLECTIVE, new ArrayList<>(Arrays.asList(ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_RELATOR, new ArrayList<>(Arrays.asList(ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_MODE, new ArrayList<>(Arrays.asList(ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_QUALITY, new ArrayList<>(Arrays.asList(ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_SUBKIND, new ArrayList<>(Arrays.asList(ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_ROLE, new ArrayList<>(Arrays.asList(ActionIds.ROLE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_PHASE, new ArrayList<>(Arrays.asList(ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_CATEGORY, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.CATEGORY, ActionIds.ROLE_MIXIN, ActionIds.PHASE_MIXIN)));
+			put(StereotypeUtils.STR_MIXIN, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.CATEGORY, ActionIds.MIXIN, ActionIds.ROLE_MIXIN, ActionIds.PHASE_MIXIN, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_ROLE_MIXIN, new ArrayList<>(Arrays.asList(ActionIds.ROLE, ActionIds.ROLE_MIXIN, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_PHASE_MIXIN, new ArrayList<>(Arrays.asList(ActionIds.PHASE, ActionIds.PHASE_MIXIN)));
+			put(StereotypeUtils.STR_HISTORICAL_ROLE, new ArrayList<>(Arrays.asList(ActionIds.ROLE, ActionIds.HISTORICAL_ROLE)));
+			put(StereotypeUtils.STR_EVENT, new ArrayList<>(Arrays.asList(ActionIds.EVENT)));
+			put(StereotypeUtils.STR_TYPE, new ArrayList<>(Arrays.asList(ActionIds.ROLE, ActionIds.PHASE, ActionIds.HISTORICAL_ROLE, ActionIds.TYPE)));
+			put(StereotypeUtils.STR_DATATYPE, new ArrayList<>(Arrays.asList(ActionIds.DATATYPE)));
+			put(StereotypeUtils.STR_ENUMERATION, new ArrayList<>(Arrays.asList(ActionIds.ENUMERATION)));			
+		}
+	};
+	
+	@SuppressWarnings("serial")
+	public static final Map<String, ArrayList<String>> allowedSuperCombinations = new HashMap<String, ArrayList<String>>() {
+		{
+			put(StereotypeUtils.STR_KIND, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_QUANTITY, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_COLLECTIVE, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_RELATOR, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_MODE, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_QUALITY, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_SUBKIND, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.CATEGORY, ActionIds.MIXIN, ActionIds.ROLE_MIXIN, ActionIds.HISTORICAL_ROLE, ActionIds.TYPE)));
+			put(StereotypeUtils.STR_ROLE, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.MIXIN, ActionIds.ROLE_MIXIN, ActionIds.HISTORICAL_ROLE, ActionIds.TYPE)));
+			put(StereotypeUtils.STR_PHASE, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.PHASE, ActionIds.MIXIN, ActionIds.PHASE_MIXIN, ActionIds.TYPE)));
+			put(StereotypeUtils.STR_CATEGORY, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_MIXIN, new ArrayList<>(Arrays.asList(ActionIds.MIXIN)));
+			put(StereotypeUtils.STR_ROLE_MIXIN, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN, ActionIds.ROLE_MIXIN)));
+			put(StereotypeUtils.STR_PHASE_MIXIN, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN, ActionIds.PHASE_MIXIN)));
+			put(StereotypeUtils.STR_HISTORICAL_ROLE, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.MIXIN, ActionIds.ROLE_MIXIN, ActionIds.HISTORICAL_ROLE, ActionIds.TYPE)));
+			put(StereotypeUtils.STR_EVENT, new ArrayList<>(Arrays.asList(ActionIds.EVENT)));
+			put(StereotypeUtils.STR_TYPE, new ArrayList<>(Arrays.asList(ActionIds.TYPE)));
+			put(StereotypeUtils.STR_DATATYPE, new ArrayList<>(Arrays.asList(ActionIds.DATATYPE)));
+			put(StereotypeUtils.STR_ENUMERATION, new ArrayList<>(Arrays.asList(ActionIds.ENUMERATION)));			
+		}
+	};
+}

--- a/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ClassConstraints.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ClassConstraints.java
@@ -42,7 +42,7 @@ public class ClassConstraints {
 			put(StereotypeUtils.STR_RELATOR, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
 			put(StereotypeUtils.STR_MODE, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
 			put(StereotypeUtils.STR_QUALITY, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
-			put(StereotypeUtils.STR_SUBKIND, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.CATEGORY, ActionIds.MIXIN, ActionIds.ROLE_MIXIN, ActionIds.HISTORICAL_ROLE, ActionIds.TYPE)));
+			put(StereotypeUtils.STR_SUBKIND, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.CATEGORY, ActionIds.MIXIN, ActionIds.TYPE)));
 			put(StereotypeUtils.STR_ROLE, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.MIXIN, ActionIds.ROLE_MIXIN, ActionIds.HISTORICAL_ROLE, ActionIds.TYPE)));
 			put(StereotypeUtils.STR_PHASE, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.PHASE, ActionIds.MIXIN, ActionIds.PHASE_MIXIN, ActionIds.TYPE)));
 			put(StereotypeUtils.STR_CATEGORY, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));

--- a/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ClassConstraints.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ClassConstraints.java
@@ -42,7 +42,7 @@ public class ClassConstraints {
 			put(StereotypeUtils.STR_RELATOR, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
 			put(StereotypeUtils.STR_MODE, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
 			put(StereotypeUtils.STR_QUALITY, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));
-			put(StereotypeUtils.STR_SUBKIND, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.CATEGORY, ActionIds.MIXIN, ActionIds.TYPE)));
+			put(StereotypeUtils.STR_SUBKIND, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.CATEGORY, ActionIds.MIXIN)));
 			put(StereotypeUtils.STR_ROLE, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.ROLE, ActionIds.PHASE, ActionIds.MIXIN, ActionIds.ROLE_MIXIN, ActionIds.HISTORICAL_ROLE, ActionIds.TYPE)));
 			put(StereotypeUtils.STR_PHASE, new ArrayList<>(Arrays.asList(ActionIds.KIND, ActionIds.QUANTITY, ActionIds.COLLECTIVE, ActionIds.RELATOR, ActionIds.MODE, ActionIds.QUALITY, ActionIds.SUBKIND, ActionIds.PHASE, ActionIds.MIXIN, ActionIds.PHASE_MIXIN, ActionIds.TYPE)));
 			put(StereotypeUtils.STR_CATEGORY, new ArrayList<>(Arrays.asList(ActionIds.CATEGORY, ActionIds.MIXIN)));

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/ProjectConfigurations.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/ProjectConfigurations.java
@@ -17,6 +17,7 @@ public class ProjectConfigurations {
 	public static final boolean DEFAULT_IS_CUSTOM_SERVER_ENABLED = false;
 	public static final boolean DEFAULT_IS_EXPORT_ENABLED = true;
 	public static final boolean DEFAULT_IS_AUTOMATIC_COLORING_ENABLED = true;
+	public static final boolean DEFAULT_IS_AUTOMATIC_MODELLING_ENABLED = true;
 	public static final String DEFAULT_SERVER_URL = "http://api.ontouml.org";
 	public static final String DEFAULT_EXPORT_PATH = System.getProperty("user.home");
 	public static final String DEFAULT_EXPORT_FILENAME = "";
@@ -62,6 +63,10 @@ public class ProjectConfigurations {
 	@SerializedName("isAutomaticColoringEnabled")
 	@Expose()
 	private boolean isAutomaticColoringEnabled;
+	
+	@SerializedName("isSmartModellingEnabled")
+	@Expose()
+	private boolean isSmartModellingEnabled;
 
 	/**
 	 *
@@ -103,7 +108,8 @@ public class ProjectConfigurations {
 		this.exportGUFOFolderPath = ProjectConfigurations.DEFAULT_GUFO_EXPORT_PATH;
 		this.exportGUFOFileName = ProjectConfigurations.DEFAULT_GUFO_EXPORT_FILENAME;
 		
-		this.isAutomaticColoringEnabled = ProjectConfigurations.DEFAULT_IS_AUTOMATIC_COLORING_ENABLED;;
+		this.isAutomaticColoringEnabled = ProjectConfigurations.DEFAULT_IS_AUTOMATIC_COLORING_ENABLED;
+		this.isSmartModellingEnabled = ProjectConfigurations.DEFAULT_IS_AUTOMATIC_MODELLING_ENABLED;
 	}
 	
 	/**
@@ -294,6 +300,30 @@ public class ProjectConfigurations {
 	 */
 	public void setAutomaticColoringEnabled(boolean isAutomaticColoringEnabled) {
 		this.isAutomaticColoringEnabled = isAutomaticColoringEnabled;
+	}
+	
+	/**
+	 * 
+	 * Checks if class stereotypes should be automatically disabled..
+	 * 
+	 * @return <code>true</code> if plugin is enabled <b>and</b> smart modelling is enabled.
+	 * 
+	 * @see <code>{@link #isOntoUMLPluginEnabled()}</code>
+	 * 
+	 */
+	public boolean isSmartModellingEnabled() {
+		return isOntoUMLPluginEnabled() && isSmartModellingEnabled;
+	}
+	
+	/**
+	 * 
+	 * Sets if class stereotypes should be automatically disabled.
+	 * 
+	 * @param isSmartModellingEnabled
+	 * 
+	 */
+	public void setSmartModellingEnabled(boolean isSmartModellingEnabled) {
+		this.isSmartModellingEnabled = isSmartModellingEnabled;
 	}
 	
 	

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
@@ -274,12 +274,9 @@ public class SmartModelling {
 		final ISimpleRelationship[] relationshipsTo = _class.toToRelationshipArray();
 		final ISimpleRelationship[] relationshipsFrom = _class.toFromRelationshipArray();
 		
-		System.out.println("ENTREI MANAGE CLASS ");
-		
 		action.setEnabled(true);
 
 		for (int i = 0; relationshipsTo != null && i < relationshipsTo.length; i++) {
-			System.out.println("ENTREI NO PRIMEIRO FOR ");
 			final ISimpleRelationship relationshipTo = relationshipsTo[i];
 			final String relationshipTypeTo = relationshipTo.getModelType();
 			final String superClassType = relationshipTo.getFrom() != null ? relationshipTo.getFrom().getModelType() : "";
@@ -299,8 +296,6 @@ public class SmartModelling {
 				action.setEnabled(false);
 				continue;
 			}
-			
-			System.out.println("PRIMEIRO FOR STEREOTYPE " + superClassStereotypes.get(0));
 				
 			final String superStereotype = superClassStereotypes.get(0);
 			final ArrayList<String> allowedCombinationsSub = ClassConstraints.allowedSubCombinations.get(superStereotype);
@@ -314,7 +309,6 @@ public class SmartModelling {
 		}
 
 		for (int i = 0; relationshipsFrom != null && i < relationshipsFrom.length; i++) {
-			System.out.println("ENTREI NO SEGUNDO FOR ");
 			final ISimpleRelationship relationshipFrom = relationshipsFrom[i];
 			final String relationshipTypeFrom = relationshipFrom.getModelType();
 			final String subClassType = relationshipFrom.getTo() != null ? relationshipFrom.getFrom().getModelType() : "";
@@ -334,8 +328,6 @@ public class SmartModelling {
 				action.setEnabled(false);
 				continue;
 			}
-			
-			System.out.println("SEGUNDO FOR STEREOTYPE " + subClassStereotypes.get(0));
 
 			final String subStereotype = subClassStereotypes.get(0);
 			final ArrayList<String> allowedCombinationsSuper = ClassConstraints.allowedSuperCombinations.get(subStereotype);

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
@@ -287,25 +287,14 @@ public class SmartModelling {
 			final IClass superClass = (IClass) relationshipTo.getFrom();
 			final ArrayList<String> superClassStereotypes = new ArrayList<String>(Arrays.asList(superClass.toStereotypeArray()));
 
-			if (superClassStereotypes.size() == 0){
-				action.setEnabled(true);
-				continue;
-			}
-
-			if (superClassStereotypes.size() > 1){
+			if (superClassStereotypes.size() > 1)
 				action.setEnabled(false);
-				continue;
-			}
-				
+			
 			final String superStereotype = superClassStereotypes.get(0);
 			final ArrayList<String> allowedCombinationsSub = ClassConstraints.allowedSubCombinations.get(superStereotype);
 
-			if (allowedCombinationsSub == null || !allowedCombinationsSub.contains(action.getActionId())) {
+			if (allowedCombinationsSub == null || !allowedCombinationsSub.contains(action.getActionId()))
 				action.setEnabled(false);
-			} else {
-				action.setEnabled(true);
-			}
-
 		}
 
 		for (int i = 0; relationshipsFrom != null && i < relationshipsFrom.length; i++) {
@@ -319,27 +308,16 @@ public class SmartModelling {
 			final IClass subClass = (IClass) relationshipFrom.getTo();
 			final ArrayList<String> subClassStereotypes = new ArrayList<String>(Arrays.asList(subClass.toStereotypeArray()));
 
-			if (subClassStereotypes.size() == 0){
-				action.setEnabled(true);
-				continue;
-			}
-
-			if (subClassStereotypes.size() > 1){
+			if (subClassStereotypes.size() > 1)
 				action.setEnabled(false);
-				continue;
-			}
 
 			final String subStereotype = subClassStereotypes.get(0);
 			final ArrayList<String> allowedCombinationsSuper = ClassConstraints.allowedSuperCombinations.get(subStereotype);
 
-			if (allowedCombinationsSuper == null || !allowedCombinationsSuper.contains(action.getActionId())) {
+			if (allowedCombinationsSuper == null || !allowedCombinationsSuper.contains(action.getActionId()))
 				action.setEnabled(false);
-			} else {
-				action.setEnabled(true);
-			}
-
 		}
-
+		
 		return;
 	}
 

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
@@ -1,9 +1,18 @@
 package it.unibz.inf.ontouml.vp.utils;
 
+import it.unibz.inf.ontouml.vp.features.constraints.AssociationConstraints;
+import it.unibz.inf.ontouml.vp.features.constraints.ClassConstraints;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.AbstractMap.SimpleEntry;
+
+import com.vp.plugin.action.VPAction;
 import com.vp.plugin.model.IAssociation;
 import com.vp.plugin.model.IAssociationEnd;
 import com.vp.plugin.model.IClass;
 import com.vp.plugin.model.IModelElement;
+import com.vp.plugin.model.ISimpleRelationship;
 import com.vp.plugin.model.factory.IModelElementFactory;
 
 public class SmartModelling {
@@ -42,29 +51,28 @@ public class SmartModelling {
 		}
 	}
 
-	private static String getTypeStereotype(IAssociationEnd associationEnd){
+	private static String getTypeStereotype(IAssociationEnd associationEnd) {
 		String noStereotype = "";
-		
+
 		try {
 			final IModelElement type = associationEnd.getTypeAsElement();
-			
-			if(!type.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS))
+
+			if (!type.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS))
 				return noStereotype;
-			
+
 			final String[] stereotypes = ((IClass) type).toStereotypeArray();
 
-			if(stereotypes!=null && stereotypes.length==1)
+			if (stereotypes != null && stereotypes.length == 1)
 				return stereotypes[0];
-			
+
 			return noStereotype;
-		}
-		catch(Exception e){
+		} catch (Exception e) {
 			return noStereotype;
 		}
 	}
 
 	public static void setAssociationMetaProperties(IAssociation association) {
-		
+
 		IAssociationEnd source = (IAssociationEnd) association.getFromEnd();
 		IAssociationEnd target = (IAssociationEnd) association.getToEnd();
 
@@ -76,149 +84,271 @@ public class SmartModelling {
 
 		String[] stereotypes = association.toStereotypeArray();
 
-		if (stereotypes==null || stereotypes.length!=1)
+		if (stereotypes == null || stereotypes.length != 1)
 			return;
 
 		switch (stereotypes[0]) {
-			case StereotypeUtils.STR_CHARACTERIZATION:
-				setCardinalityIfEmpty(source, "1");
-				setCardinalityIfEmpty(target, "1");
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_COMPARATIVE:
+		case StereotypeUtils.STR_CHARACTERIZATION:
+			setCardinalityIfEmpty(source, "1");
+			setCardinalityIfEmpty(target, "1");
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_COMPARATIVE:
+			setCardinalityIfEmpty(source, "0..*");
+			setCardinalityIfEmpty(target, "0..*");
+			association.setDerived(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_COMPONENT_OF:
+			setCardinalityIfEmpty(source, "1..*");
+			setCardinalityIfEmpty(target, "1");
+			setAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_MATERIAL:
+			if (targetStereotype.equals(StereotypeUtils.STR_ROLE))
+				setCardinalityIfEmpty(source, "1..*");
+			else
 				setCardinalityIfEmpty(source, "0..*");
+
+			if (sourceStereotype.equals(StereotypeUtils.STR_ROLE))
+				setCardinalityIfEmpty(target, "1..*");
+			else
 				setCardinalityIfEmpty(target, "0..*");
-				association.setDerived(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_COMPONENT_OF:
+
+			association.setDerived(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_EXTERNAL_DEPENDENCE:
+			setCardinalityIfEmpty(source, "0..*");
+			setCardinalityIfEmpty(target, "1..*");
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_MEDIATION:
+			if (targetStereotype.equals(StereotypeUtils.STR_ROLE))
 				setCardinalityIfEmpty(source, "1..*");
-				setCardinalityIfEmpty(target, "1");
-				setAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_MATERIAL:
-				if(targetStereotype.equals(StereotypeUtils.STR_ROLE))
-					setCardinalityIfEmpty(source, "1..*");
-				else
-					setCardinalityIfEmpty(source, "0..*");
-					
-				if(sourceStereotype.equals(StereotypeUtils.STR_ROLE))
-					setCardinalityIfEmpty(target, "1..*");
-				else
-					setCardinalityIfEmpty(target, "0..*");
-				
-					association.setDerived(true);
-					removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_EXTERNAL_DEPENDENCE:
+			else
 				setCardinalityIfEmpty(source, "0..*");
-				setCardinalityIfEmpty(target, "1..*");
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_MEDIATION:
-				if(targetStereotype.equals(StereotypeUtils.STR_ROLE))
-					setCardinalityIfEmpty(source, "1..*");
-				else
-					setCardinalityIfEmpty(source, "0..*");
-				
-				setCardinalityIfEmpty(target, "1");
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_MEMBER_OF:
+
+			setCardinalityIfEmpty(target, "1");
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_MEMBER_OF:
+			setCardinalityIfEmpty(source, "1..*");
+			setCardinalityIfEmpty(target, "1..*");
+			setAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_SUB_COLLECTION_OF:
+			setCardinalityIfEmpty(source, "1");
+			setCardinalityIfEmpty(target, "1");
+			setAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_SUB_QUANTITY_OF:
+			setCardinalityIfEmpty(source, "1");
+			setCardinalityIfEmpty(target, "1");
+			source.setReadOnly(true);
+			setAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_CREATION:
+			setCardinalityIfEmpty(source, "1");
+			setCardinalityIfEmpty(target, "1");
+			source.setReadOnly(true);
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_HISTORICAL_DEPENDENCE:
+			setCardinalityIfEmpty(source, "0..*");
+			setCardinalityIfEmpty(target, "1");
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_MANIFESTATION:
+			setCardinalityIfEmpty(source, "0..*");
+			setCardinalityIfEmpty(target, "1..*");
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_PARTICIPATION:
+			if (targetStereotype.equals(StereotypeUtils.STR_HISTORICAL_ROLE))
 				setCardinalityIfEmpty(source, "1..*");
-				setCardinalityIfEmpty(target, "1..*");
-				setAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_SUB_COLLECTION_OF:
-				setCardinalityIfEmpty(source, "1");
-				setCardinalityIfEmpty(target, "1");
-				setAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_SUB_QUANTITY_OF:
-				setCardinalityIfEmpty(source, "1");
-				setCardinalityIfEmpty(target, "1");
-				source.setReadOnly(true);
-				setAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_CREATION:
-				setCardinalityIfEmpty(source, "1");
-				setCardinalityIfEmpty(target, "1");
-				source.setReadOnly(true);
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_HISTORICAL_DEPENDENCE:
+			else
 				setCardinalityIfEmpty(source, "0..*");
-				setCardinalityIfEmpty(target, "1");
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_MANIFESTATION:
-				setCardinalityIfEmpty(source, "0..*");
-				setCardinalityIfEmpty(target, "1..*");
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_PARTICIPATION:
-				if(targetStereotype.equals(StereotypeUtils.STR_HISTORICAL_ROLE))
-					setCardinalityIfEmpty(source, "1..*");
-				else
-					setCardinalityIfEmpty(source, "0..*");
-				
-				setCardinalityIfEmpty(target, "1..*");
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_PARTICIPATIONAL:
-				setCardinalityIfEmpty(source, "1..*");
-				setCardinalityIfEmpty(target, "1");
-				source.setReadOnly(true);
-				target.setReadOnly(true);
-				setAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_TERMINATION:
-				setCardinalityIfEmpty(source, "1");
-				setCardinalityIfEmpty(target, "1");
-				source.setReadOnly(true);
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
-			case StereotypeUtils.STR_INSTANTIATION:
-				setCardinalityIfEmpty(source, "0..*");
-				setCardinalityIfEmpty(target, "1..*");
-				source.setReadOnly(true);
-				target.setReadOnly(true);
-				removeAggregationKind(association);
-				return;
+
+			setCardinalityIfEmpty(target, "1..*");
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_PARTICIPATIONAL:
+			setCardinalityIfEmpty(source, "1..*");
+			setCardinalityIfEmpty(target, "1");
+			source.setReadOnly(true);
+			target.setReadOnly(true);
+			setAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_TERMINATION:
+			setCardinalityIfEmpty(source, "1");
+			setCardinalityIfEmpty(target, "1");
+			source.setReadOnly(true);
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
+		case StereotypeUtils.STR_INSTANTIATION:
+			setCardinalityIfEmpty(source, "0..*");
+			setCardinalityIfEmpty(target, "1..*");
+			source.setReadOnly(true);
+			target.setReadOnly(true);
+			removeAggregationKind(association);
+			return;
 		}
 	}
 
 	public static void setClassMetaProperties(IClass _class) {
-		if(_class==null)
+		if (_class == null)
 			return;
-			
+
 		String[] stereotypes = _class.toStereotypeArray();
 
-		if (stereotypes==null || stereotypes.length!=1)
+		if (stereotypes == null || stereotypes.length != 1)
 			return;
 
 		switch (stereotypes[0]) {
-			case StereotypeUtils.STR_CATEGORY:
-				_class.setAbstract(true);
-				break;
-			case StereotypeUtils.STR_ROLE_MIXIN:
-				_class.setAbstract(true);
-				break;
-			case StereotypeUtils.STR_PHASE_MIXIN:
-				_class.setAbstract(true);
-				break;
-			case StereotypeUtils.STR_MIXIN:
-				_class.setAbstract(true);
-				break;
+		case StereotypeUtils.STR_CATEGORY:
+			_class.setAbstract(true);
+			break;
+		case StereotypeUtils.STR_ROLE_MIXIN:
+			_class.setAbstract(true);
+			break;
+		case StereotypeUtils.STR_PHASE_MIXIN:
+			_class.setAbstract(true);
+			break;
+		case StereotypeUtils.STR_MIXIN:
+			_class.setAbstract(true);
+			break;
 		}
+	}
+
+	public static void manageAssociationStereotypes(IAssociation association, VPAction action) {
+
+		if (!association.getFrom().getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS))
+			return;
+
+		if (!association.getTo().getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS))
+			return;
+
+		final IClass source = (IClass) association.getFrom();
+		final IClass target = (IClass) association.getTo();
+
+		final ArrayList<String> sourceStereotypes = new ArrayList<String>(Arrays.asList(source.toStereotypeArray()));
+		final ArrayList<String> targetStereotypes = new ArrayList<String>(Arrays.asList(target.toStereotypeArray()));
+
+		if (sourceStereotypes.size() == 0 || targetStereotypes.size() == 0) {
+			// if any end has no stereotypes everything is allowed
+			action.setEnabled(true);
+			return;
+		}
+
+		if (sourceStereotypes.size() > 1 || targetStereotypes.size() > 1) {
+			// if any end has more than 1 stereotypes nothing is allowed
+			action.setEnabled(false);
+			return;
+		}
+
+		// continue if both ends has ONLY ONE stereotype in both ends
+		final String sourceStereotype = sourceStereotypes.get(0);
+		final String targetStereotype = targetStereotypes.get(0);
+		final ArrayList<String> allowedCombinations = AssociationConstraints.allowedCombinations.get(new SimpleEntry<String, String>(sourceStereotype, targetStereotype));
+
+		if (allowedCombinations == null || !allowedCombinations.contains(action.getActionId())) {
+			action.setEnabled(false);
+		} else {
+			action.setEnabled(true);
+		}
+
+		return;
+	}
+
+	public static void manageClassStereotypes(IClass _class, VPAction action) {
+
+		final ISimpleRelationship[] relationshipsTo = _class.toToRelationshipArray();
+		final ISimpleRelationship[] relationshipsFrom = _class.toFromRelationshipArray();
+		
+		System.out.println("ENTREI MANAGE CLASS ");
+		
+		action.setEnabled(true);
+
+		for (int i = 0; relationshipsTo != null && i < relationshipsTo.length; i++) {
+			System.out.println("ENTREI NO PRIMEIRO FOR ");
+			final ISimpleRelationship relationshipTo = relationshipsTo[i];
+			final String relationshipTypeTo = relationshipTo.getModelType();
+			final String superClassType = relationshipTo.getFrom() != null ? relationshipTo.getFrom().getModelType() : "";
+
+			if (!(relationshipTypeTo.equals(IModelElementFactory.MODEL_TYPE_GENERALIZATION)) || !(superClassType.equals(IModelElementFactory.MODEL_TYPE_CLASS)))
+				continue;
+
+			final IClass superClass = (IClass) relationshipTo.getFrom();
+			final ArrayList<String> superClassStereotypes = new ArrayList<String>(Arrays.asList(superClass.toStereotypeArray()));
+
+			if (superClassStereotypes.size() == 0){
+				action.setEnabled(true);
+				continue;
+			}
+
+			if (superClassStereotypes.size() > 1){
+				action.setEnabled(false);
+				continue;
+			}
+			
+			System.out.println("PRIMEIRO FOR STEREOTYPE " + superClassStereotypes.get(0));
+				
+			final String superStereotype = superClassStereotypes.get(0);
+			final ArrayList<String> allowedCombinationsSub = ClassConstraints.allowedSubCombinations.get(superStereotype);
+
+			if (allowedCombinationsSub == null || !allowedCombinationsSub.contains(action.getActionId())) {
+				action.setEnabled(false);
+			} else {
+				action.setEnabled(true);
+			}
+
+		}
+
+		for (int i = 0; relationshipsFrom != null && i < relationshipsFrom.length; i++) {
+			System.out.println("ENTREI NO SEGUNDO FOR ");
+			final ISimpleRelationship relationshipFrom = relationshipsFrom[i];
+			final String relationshipTypeFrom = relationshipFrom.getModelType();
+			final String subClassType = relationshipFrom.getTo() != null ? relationshipFrom.getFrom().getModelType() : "";
+
+			if (!(relationshipTypeFrom.equals(IModelElementFactory.MODEL_TYPE_GENERALIZATION)) || !(subClassType.equals(IModelElementFactory.MODEL_TYPE_CLASS)))
+				continue;
+
+			final IClass subClass = (IClass) relationshipFrom.getTo();
+			final ArrayList<String> subClassStereotypes = new ArrayList<String>(Arrays.asList(subClass.toStereotypeArray()));
+
+			if (subClassStereotypes.size() == 0){
+				action.setEnabled(true);
+				continue;
+			}
+
+			if (subClassStereotypes.size() > 1){
+				action.setEnabled(false);
+				continue;
+			}
+			
+			System.out.println("SEGUNDO FOR STEREOTYPE " + subClassStereotypes.get(0));
+
+			final String subStereotype = subClassStereotypes.get(0);
+			final ArrayList<String> allowedCombinationsSuper = ClassConstraints.allowedSuperCombinations.get(subStereotype);
+
+			if (allowedCombinationsSuper == null || !allowedCombinationsSuper.contains(action.getActionId())) {
+				action.setEnabled(false);
+			} else {
+				action.setEnabled(true);
+			}
+
+		}
+
+		return;
 	}
 
 }

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
@@ -287,6 +287,9 @@ public class SmartModelling {
 			final IClass superClass = (IClass) relationshipTo.getFrom();
 			final ArrayList<String> superClassStereotypes = new ArrayList<String>(Arrays.asList(superClass.toStereotypeArray()));
 
+			if (superClassStereotypes.size()==0)
+				continue;
+
 			if (superClassStereotypes.size() > 1)
 				action.setEnabled(false);
 			
@@ -307,6 +310,9 @@ public class SmartModelling {
 
 			final IClass subClass = (IClass) relationshipFrom.getTo();
 			final ArrayList<String> subClassStereotypes = new ArrayList<String>(Arrays.asList(subClass.toStereotypeArray()));
+
+			if (subClassStereotypes.size()==0)
+				continue;
 
 			if (subClassStereotypes.size() > 1)
 				action.setEnabled(false);

--- a/src/main/java/it/unibz/inf/ontouml/vp/views/ConfigurationsView.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/views/ConfigurationsView.java
@@ -97,10 +97,30 @@ public class ConfigurationsView extends JPanel {
 		gbl__exportPanel.rowWeights = new double[]{0.0, Double.MIN_VALUE};
 		_exportPanel.setLayout(gbl__exportPanel);
 		
+		JPanel _smartPanel = new JPanel();
+		_optionsPanel.add(_smartPanel);
+		GridBagLayout gbl__smartPanel = new GridBagLayout();
+		gbl__smartPanel.columnWidths = new int[]{290, 247, 0, 0};
+		gbl__smartPanel.rowHeights = new int[]{0, 0};
+		gbl__smartPanel.columnWeights = new double[]{0.0, 0.0, 0.0, Double.MIN_VALUE};
+		gbl__smartPanel.rowWeights = new double[]{0.0, Double.MIN_VALUE};
+		_smartPanel.setLayout(gbl__smartPanel);
+			
 		_chckbxEnableAutoColoring = new JCheckBox("Enable Smart Paint");
+		GridBagConstraints gbc__chckbxEnableAutoColoring = new GridBagConstraints();
+		gbc__chckbxEnableAutoColoring.anchor = GridBagConstraints.WEST;
+		gbc__chckbxEnableAutoColoring.insets = new Insets(0, 0, 0, 5);
+		gbc__chckbxEnableAutoColoring.gridx = 0;
+		gbc__chckbxEnableAutoColoring.gridy = 0;
+		_smartPanel.add(_chckbxEnableAutoColoring, gbc__chckbxEnableAutoColoring);
+		
 		_chckbxEnableSmartModelling = new JCheckBox("Enable Smart Modelling");
-		_optionsPanel.add(_chckbxEnableAutoColoring);
-		_optionsPanel.add(_chckbxEnableSmartModelling);
+		GridBagConstraints gbc__chckbxEnableSmartModelling = new GridBagConstraints();
+		gbc__chckbxEnableSmartModelling.anchor = GridBagConstraints.WEST;
+		gbc__chckbxEnableSmartModelling.insets = new Insets(0, 0, 0, 5);
+		gbc__chckbxEnableSmartModelling.gridx = 0;
+		gbc__chckbxEnableSmartModelling.gridy = 1;
+		_smartPanel.add(_chckbxEnableSmartModelling, gbc__chckbxEnableSmartModelling);
 		
 		JPanel _controlButtonsPanel = new JPanel();
 		GridBagConstraints gbc__controlButtonsPanel = new GridBagConstraints();

--- a/src/main/java/it/unibz/inf/ontouml/vp/views/ConfigurationsView.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/views/ConfigurationsView.java
@@ -27,6 +27,7 @@ public class ConfigurationsView extends JPanel {
 	private JTextField _txtServerAddress;
 	
 	private JCheckBox _chckbxEnableAutoColoring;
+	private JCheckBox _chckbxEnableSmartModelling;
 	
 	private JButton _btnApply;
 	private JButton _btnResetDefaults;
@@ -97,7 +98,9 @@ public class ConfigurationsView extends JPanel {
 		_exportPanel.setLayout(gbl__exportPanel);
 		
 		_chckbxEnableAutoColoring = new JCheckBox("Enable Smart Paint");
+		_chckbxEnableSmartModelling = new JCheckBox("Enable Smart Modelling");
 		_optionsPanel.add(_chckbxEnableAutoColoring);
+		_optionsPanel.add(_chckbxEnableSmartModelling);
 		
 		JPanel _controlButtonsPanel = new JPanel();
 		GridBagConstraints gbc__controlButtonsPanel = new GridBagConstraints();
@@ -171,6 +174,7 @@ public class ConfigurationsView extends JPanel {
 		configurations.setServerURL(_txtServerAddress.getText());
 		
 		configurations.setAutomaticColoringEnabled(_chckbxEnableAutoColoring.isSelected());
+		configurations.setSmartModellingEnabled(_chckbxEnableSmartModelling.isSelected());
 	}
 	
 	/**
@@ -185,6 +189,7 @@ public class ConfigurationsView extends JPanel {
 		_txtServerAddress.setText(configurations.getServerURL());
 		
 		_chckbxEnableAutoColoring.setSelected(configurations.isAutomaticColoringEnabled());
+		_chckbxEnableSmartModelling.setSelected(configurations.isSmartModellingEnabled());
 	}
 	
 	/**
@@ -197,6 +202,7 @@ public class ConfigurationsView extends JPanel {
 		_txtServerAddress.setText(ProjectConfigurations.DEFAULT_SERVER_URL);
 
 		_chckbxEnableAutoColoring.setSelected(ProjectConfigurations.DEFAULT_IS_AUTOMATIC_COLORING_ENABLED);
+		_chckbxEnableSmartModelling.setSelected(ProjectConfigurations.DEFAULT_IS_AUTOMATIC_COLORING_ENABLED);
 	}
 	
 	/**
@@ -208,6 +214,7 @@ public class ConfigurationsView extends JPanel {
 		_chckbxEnableCustomServer.setEnabled(true);
 		_txtServerAddress.setEnabled(_chckbxEnableCustomServer.isSelected());
 		_chckbxEnableAutoColoring.setEnabled(true);	
+		_chckbxEnableSmartModelling.setEnabled(true);	
 	}
 
 }


### PR DESCRIPTION
This is a new feature that implements in the plugin the ability to disable stereotypes as the user is building the generalizations based in a set of [rules](https://docs.google.com/spreadsheets/d/17U1fwKTx4SN7ACP3GJ-4qJEUJrzztLc-TtkqEsPRcWY/edit#gid=1544524275). This can be turned on/off in the configurations panel.

Fixes #23 