### PR TITLE
Issue30 add multiple stereotypes

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -81,7 +81,7 @@
         <contextSensitiveActionSet id="it.unibz.inf.ontouml.vp.ClassStereotypes">
             <contextTypes all="false"/>
             <include type="Class"/>
-            <menu id="ontoUMLMenu1" label="OntoUML Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
+            <menu id="ontoUMLMenu1" label="OntoUML Suggested Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
             
 
             <action id="it.unibz.inf.ontouml.vp.addEnumerationStereotype" label="Enumeration" style="normal" menuPath="ontoUMLMenu1/#">
@@ -172,7 +172,7 @@
             <contextTypes all="false"/>
             <include type="Association"/>
             
-            <menu id="ontoUMLMenu2" label="OntoUML Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
+            <menu id="ontoUMLMenu2" label="OntoUML Suggested Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
                 
             <action id="it.unibz.inf.ontouml.vp.addInstantiationStereotype" label="Instantiation" style="normal" menuPath="ontoUMLMenu2/#">
                 <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotype"/>
@@ -244,18 +244,185 @@
             
         </contextSensitiveActionSet>
 
+        
+        <contextSensitiveActionSet id="it.unibz.inf.ontouml.vp.ClassStereotypes">
+            <contextTypes all="false"/>
+            <include type="Class"/>
+            <menu id="ontoUMLMenu1.fixedMenu" label="OntoUML Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
+            
+
+            <action id="it.unibz.inf.ontouml.vp.addEnumerationStereotype.fixedMenu" label="Enumeration" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addDatatypeStereotype.fixedMenu" label="Datatype" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <separator id="it.unibz.inf.ontouml.vp.separator0.fixedMenu" menuPath="ontoUMLMenu1.fixedMenu/#" />
+
+            <action id="it.unibz.inf.ontouml.vp.addTypeStereotype.fixedMenu" label="Type" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+          <!-- POWERTYPE REMOVED IN 17 FEV 2020  <action id="it.unibz.inf.ontouml.vp.addPowertypeStereotype.fixedMenu" label="Powertype" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action> -->
+    
+            <separator id="it.unibz.inf.ontouml.vp.separator2.fixedMenu" menuPath="ontoUMLMenu1.fixedMenu/#"/>
+
+            <action id="it.unibz.inf.ontouml.vp.addHistoricalRoleStereotype.fixedMenu" label="HistoricalRole" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addEventStereotype.fixedMenu" label="Event" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <separator id="it.unibz.inf.ontouml.vp.separator1.fixedMenu" menuPath="ontoUMLMenu1.fixedMenu/#" />
+            
+            <action id="it.unibz.inf.ontouml.vp.addSubkindStereotype.fixedMenu" label="Subkind" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addRoleMixinStereotype.fixedMenu" label="RoleMixin" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addRoleStereotype.fixedMenu" label="Role" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addRelatorStereotype.fixedMenu" label="Relator" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addQuantityStereotype.fixedMenu" label="Quantity" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addQualityStereotype.fixedMenu" label="Quality" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addPhaseMixinStereotype.fixedMenu" label="PhaseMixin" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addPhaseStereotype.fixedMenu" label="Phase" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addModeStereotype.fixedMenu" label="Mode" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addMixinStereotype.fixedMenu" label="Mixin" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addKindStereotype.fixedMenu" label="Kind" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addCollectiveStereotype.fixedMenu" label="Collective" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+        
+            <action id="it.unibz.inf.ontouml.vp.addCategoryStereotype.fixedMenu" label="Category" style="normal" menuPath="ontoUMLMenu1.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+        </contextSensitiveActionSet>
+        
+        <contextSensitiveActionSet id="it.unibz.inf.ontouml.vp.AssociationStereotypes">
+            <contextTypes all="false"/>
+            <include type="Association"/>
+            
+            <menu id="ontoUMLMenu2.fixedMenu" label="OntoUML Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
+                
+            <action id="it.unibz.inf.ontouml.vp.addInstantiationStereotype.fixedMenu" label="Instantiation" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <separator id="it.unibz.inf.ontouml.vp.AssociationSeparator1.fixedMenu" menuPath="ontoUMLMenu2.fixedMenu/#" />
+            
+            <action id="it.unibz.inf.ontouml.vp.addTerminationStereotype.fixedMenu" label="Termination" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addParticipationalStereotype.fixedMenu" label="Participational" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addParticipationStereotype.fixedMenu" label="Participation" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addHistoricalDependenceStereotype.fixedMenu" label="HistoricalDependence" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addCreationStereotype.fixedMenu" label="Creation" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addManifestationStereotype.fixedMenu" label="Manifestation" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <separator id="it.unibz.inf.ontouml.vp.AssociationSeparator0.fixedMenu" menuPath="ontoUMLMenu2.fixedMenu/#" />
+
+            <action id="it.unibz.inf.ontouml.vp.addSubQuantityStereotype.fixedMenu" label="SubQuantityOf" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addSubCollectionStereotype.fixedMenu" label="SubCollectionOf" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+                
+            <action id="it.unibz.inf.ontouml.vp.addMemberOfStereotype.fixedMenu" label="MemberOf" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addMediationStereotype.fixedMenu" label="Mediation" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addMaterialStereotype.fixedMenu" label="Material" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addExternalDependenceStereotype.fixedMenu" label="ExternalDependence" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+                
+            <action id="it.unibz.inf.ontouml.vp.addComponentOfStereotype.fixedMenu" label="ComponentOf" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+
+            <action id="it.unibz.inf.ontouml.vp.addComparativeStereotype.fixedMenu" label="Comparative" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+            <action id="it.unibz.inf.ontouml.vp.addCharacterizationStereotype.fixedMenu" label="Characterization" style="normal" menuPath="ontoUMLMenu2.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
+            </action>
+            
+        </contextSensitiveActionSet>
+
         <contextSensitiveActionSet id="it.unibz.inf.ontouml.vp.AttributeStereotypes">
             <contextTypes all="false"/>
             <include type="Attribute"/>
             
-            <menu id="ontoUMLMenu3" label="OntoUML Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
+            <menu id="ontoUMLMenu3.fixedMenu" label="OntoUML Stereotypes" mnemonic="O" menuPath="#" icon="icons/logo/ontouml-simple-logo-small.png"/>
                 
-            <action id="it.unibz.inf.ontouml.vp.addEndStereotype" label="End" style="normal" menuPath="ontoUMLMenu3/#">
-                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotype"/>
+            <action id="it.unibz.inf.ontouml.vp.addEndStereotype.fixedMenu" label="End" style="normal" menuPath="ontoUMLMenu3.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
             </action>
             
-            <action id="it.unibz.inf.ontouml.vp.addBeginStereotype" label="Begin" style="normal" menuPath="ontoUMLMenu3/#">
-                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotype"/>
+            <action id="it.unibz.inf.ontouml.vp.addBeginStereotype.fixedMenu" label="Begin" style="normal" menuPath="ontoUMLMenu3.fixedMenu/#">
+                <actionController class="it.unibz.inf.ontouml.vp.controllers.ApplyStereotypeFixedMenu"/>
             </action>
             
         </contextSensitiveActionSet>

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -31,19 +31,16 @@ public class ApplyStereotype implements VPContextActionController {
 
 	@Override
 	public void performAction(VPAction action, VPContext context, ActionEvent event) {
-
-		if (!isSelectionSameModelType()) {
-			applyStereotype(action, context.getModelElement());
-			return;
-		}
-
+		
 		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
 
 		if (diagramElements == null)
 			return;
 
-		for (IDiagramElement diagramElement : diagramElements)
-			applyStereotype(action, diagramElement.getModelElement());
+		for (IDiagramElement diagramElement : diagramElements) {
+			if (diagramElement.getModelElement().getModelType().equals(context.getModelElement().getModelType()))
+				applyStereotype(action, diagramElement.getModelElement());
+		}
 
 	}
 

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -36,8 +36,10 @@ public class ApplyStereotype implements VPContextActionController {
 
 		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
 
-		if (diagramElements == null)
+		if (diagramElements == null){
+			applyStereotype(action, context.getModelElement());
 			return;
+		}
 
 		for (IDiagramElement diagramElement : diagramElements) {
 			if (diagramElement.getModelElement().getModelType().equals(context.getModelElement().getModelType()))

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -25,6 +25,7 @@ import it.unibz.inf.ontouml.vp.utils.StereotypeUtils;
  * Implementation of context sensitive action of change OntoUML stereotypes in model elements.
  * 
  * @author Claudenir Fonseca
+ * @author Victor Viola
  *
  */
 public class ApplyStereotype implements VPContextActionController {
@@ -46,21 +47,15 @@ public class ApplyStereotype implements VPContextActionController {
 
 	@Override
 	public void update(VPAction action, VPContext context) {
-
+		action.setEnabled(true);
+		
 		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
-
-		if (diagramElements == null)
+		
+		if (diagramElements == null || diagramElements.length > 1)
 			return;
+		
+		defineActionBehavior(action, context.getModelElement());
 
-		if (Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled()) {
-
-			for (IDiagramElement diagramElement : diagramElements) {
-				if (diagramElement.getModelElement().getModelType().equals(context.getModelElement().getModelType()))
-					defineActionBehavior(action, diagramElement.getModelElement());
-			}
-		} else {
-			action.setEnabled(true);
-		}
 	}
 
 	private void applyStereotype(VPAction action, IModelElement element) {
@@ -212,4 +207,5 @@ public class ApplyStereotype implements VPContextActionController {
 			return;
 		}
 	}
+	
 }

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -31,7 +31,7 @@ public class ApplyStereotype implements VPContextActionController {
 
 	@Override
 	public void performAction(VPAction action, VPContext context, ActionEvent event) {
-		
+
 		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
 
 		if (diagramElements == null)
@@ -47,11 +47,6 @@ public class ApplyStereotype implements VPContextActionController {
 	@Override
 	public void update(VPAction action, VPContext context) {
 
-		if (!isSelectionSameModelType()) {
-			defineActionBehavior(action, context.getModelElement());
-			return;
-		}
-
 		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
 
 		if (diagramElements == null)
@@ -59,8 +54,10 @@ public class ApplyStereotype implements VPContextActionController {
 
 		if (Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled()) {
 
-			for (IDiagramElement diagramElement : diagramElements)
-				defineActionBehavior(action, diagramElement.getModelElement());
+			for (IDiagramElement diagramElement : diagramElements) {
+				if (diagramElement.getModelElement().getModelType().equals(context.getModelElement().getModelType()))
+					defineActionBehavior(action, diagramElement.getModelElement());
+			}
 		} else {
 			action.setEnabled(true);
 		}
@@ -215,22 +212,4 @@ public class ApplyStereotype implements VPContextActionController {
 			return;
 		}
 	}
-
-	private boolean isSelectionSameModelType() {
-
-		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
-		HashSet<String> elementTypes = new HashSet<String>();
-
-		if (diagramElements == null)
-			return false;
-
-		for (IDiagramElement diagramElement : diagramElements)
-			elementTypes.add(diagramElement.getModelElement().getModelType());
-
-		if (elementTypes.size() == 1)
-			return true;
-		else
-			return false;
-	}
-
 }

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotype.java
@@ -56,8 +56,10 @@ public class ApplyStereotype implements VPContextActionController {
 
 		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
 
-		if (diagramElements == null )
+		if (diagramElements == null ) {
+			defineActionBehavior(action, context.getModelElement());
 			return;
+		}
 		
 		for (IDiagramElement diagramElement : diagramElements) {
 			if (diagramElement.getModelElement().getModelType().equals(context.getModelElement().getModelType()))
@@ -222,7 +224,7 @@ public class ApplyStereotype implements VPContextActionController {
 		LinkedList<String> superClasses = new LinkedList<String>();
 
 		if (diagramElements == null)
-			return false;
+			return true;
 
 		if (diagramElements.length == 1)
 			return true;

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotypeFixedMenu.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotypeFixedMenu.java
@@ -26,8 +26,10 @@ public class ApplyStereotypeFixedMenu implements VPContextActionController {
 
 		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
 
-		if (diagramElements == null)
+		if (diagramElements == null) {
+			applyStereotype(action, context.getModelElement());
 			return;
+		}
 
 		for (IDiagramElement diagramElement : diagramElements) {
 			if (diagramElement.getModelElement().getModelType().equals(context.getModelElement().getModelType()))
@@ -38,9 +40,9 @@ public class ApplyStereotypeFixedMenu implements VPContextActionController {
 
 	@Override
 	public void update(VPAction arg0, VPContext arg1) {
-		
+
 	}
-	
+
 	private void applyStereotype(VPAction action, IModelElement element) {
 
 		final IStereotype[] stereotypes = element.toStereotypeModelArray();

--- a/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotypeFixedMenu.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/controllers/ApplyStereotypeFixedMenu.java
@@ -1,0 +1,179 @@
+package it.unibz.inf.ontouml.vp.controllers;
+
+import it.unibz.inf.ontouml.vp.features.constraints.ActionIds;
+import it.unibz.inf.ontouml.vp.utils.Configurations;
+import it.unibz.inf.ontouml.vp.utils.SmartColoring;
+import it.unibz.inf.ontouml.vp.utils.SmartModelling;
+import it.unibz.inf.ontouml.vp.utils.StereotypeUtils;
+
+import java.awt.event.ActionEvent;
+
+import com.vp.plugin.ApplicationManager;
+import com.vp.plugin.action.VPAction;
+import com.vp.plugin.action.VPContext;
+import com.vp.plugin.action.VPContextActionController;
+import com.vp.plugin.diagram.IDiagramElement;
+import com.vp.plugin.model.IAssociation;
+import com.vp.plugin.model.IClass;
+import com.vp.plugin.model.IModelElement;
+import com.vp.plugin.model.IStereotype;
+import com.vp.plugin.model.factory.IModelElementFactory;
+
+public class ApplyStereotypeFixedMenu implements VPContextActionController {
+
+	@Override
+	public void performAction(VPAction action, VPContext context, ActionEvent event) {
+
+		IDiagramElement[] diagramElements = ApplicationManager.instance().getDiagramManager().getActiveDiagram().getSelectedDiagramElement();
+
+		if (diagramElements == null)
+			return;
+
+		for (IDiagramElement diagramElement : diagramElements) {
+			if (diagramElement.getModelElement().getModelType().equals(context.getModelElement().getModelType()))
+				applyStereotype(action, diagramElement.getModelElement());
+		}
+
+	}
+
+	@Override
+	public void update(VPAction arg0, VPContext arg1) {
+		
+	}
+	
+	private void applyStereotype(VPAction action, IModelElement element) {
+
+		final IStereotype[] stereotypes = element.toStereotypeModelArray();
+
+		for (int i = 0; stereotypes != null && i < stereotypes.length; i++) {
+			element.removeStereotype(stereotypes[i]);
+		}
+
+		switch (action.getActionId()) {
+		case ActionIds.TYPE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_TYPE);
+			break;
+		case ActionIds.HISTORICAL_ROLE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_HISTORICAL_ROLE);
+			break;
+		case ActionIds.EVENT_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_EVENT);
+			break;
+		case ActionIds.ENUMERATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_ENUMERATION);
+			break;
+		case ActionIds.DATATYPE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_DATATYPE);
+			break;
+		case ActionIds.SUBKIND_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_SUBKIND);
+			break;
+		case ActionIds.ROLE_MIXIN_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_ROLE_MIXIN);
+			break;
+		case ActionIds.ROLE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_ROLE);
+			break;
+		case ActionIds.RELATOR_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_RELATOR);
+			break;
+		case ActionIds.QUANTITY_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_QUANTITY);
+			break;
+		case ActionIds.QUALITY_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_QUALITY);
+			break;
+		case ActionIds.PHASE_MIXIN_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_PHASE_MIXIN);
+			break;
+		case ActionIds.PHASE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_PHASE);
+			break;
+		case ActionIds.MODE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_MODE);
+			break;
+		case ActionIds.MIXIN_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_MIXIN);
+			break;
+		case ActionIds.KIND_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_KIND);
+			break;
+		case ActionIds.COLLECTIVE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_COLLECTIVE);
+			break;
+		case ActionIds.CATEGORY_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_CATEGORY);
+			break;
+		case ActionIds.INSTANTIATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_INSTANTIATION);
+			break;
+		case ActionIds.TERMINATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_TERMINATION);
+			break;
+		case ActionIds.PARTICIPATIONAL_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_PARTICIPATIONAL);
+			break;
+		case ActionIds.PARTICIPATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_PARTICIPATION);
+			break;
+		case ActionIds.HISTORICAL_DEPENDENCE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_HISTORICAL_DEPENDENCE);
+			break;
+		case ActionIds.CREATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_CREATION);
+			break;
+		case ActionIds.MANIFESTATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_MANIFESTATION);
+			break;
+		case ActionIds.MATERIAL_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_MATERIAL);
+			break;
+		case ActionIds.COMPARATIVE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_COMPARATIVE);
+			break;
+		case ActionIds.MEDIATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_MEDIATION);
+			break;
+		case ActionIds.CHARACTERIZATION_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_CHARACTERIZATION);
+			break;
+		case ActionIds.EXTERNAL_DEPENDENCE_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_EXTERNAL_DEPENDENCE);
+			break;
+		case ActionIds.COMPONENT_OF_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_COMPONENT_OF);
+			break;
+		case ActionIds.MEMBER_OF_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_MEMBER_OF);
+			break;
+		case ActionIds.SUB_COLLECTION_OF_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_SUB_COLLECTION_OF);
+			break;
+		case ActionIds.SUB_QUANTITY_OF_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_SUB_QUANTITY_OF);
+			break;
+		case ActionIds.BEGIN_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_BEGIN);
+			break;
+		case ActionIds.END_FIXEDMENU:
+			element.addStereotype(StereotypeUtils.STR_END);
+			break;
+		}
+
+		boolean isSmartModelingEnabled = Configurations.getInstance().getProjectConfigurations().isSmartModellingEnabled();
+
+		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_CLASS)) {
+			if (isSmartModelingEnabled)
+				SmartModelling.setClassMetaProperties((IClass) element);
+		}
+
+		if (element.getModelType().equals(IModelElementFactory.MODEL_TYPE_ASSOCIATION)) {
+			if (isSmartModelingEnabled)
+				SmartModelling.setAssociationMetaProperties((IAssociation) element);
+		}
+
+		if (Configurations.getInstance().getProjectConfigurations().isAutomaticColoringEnabled())
+			SmartColoring.smartPaint();
+	}
+
+}

--- a/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ActionIds.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/features/constraints/ActionIds.java
@@ -49,4 +49,52 @@ public final class ActionIds {
 	// Attribute stereotypes (ordered as in plugin.xml)
 	public static final String END = "it.unibz.inf.ontouml.vp.addEndStereotype";
 	public static final String BEGIN = "it.unibz.inf.ontouml.vp.addBeginStereotype";
+	
+	//Fixed Menu ActionIds
+	public static final String TYPE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addTypeStereotype.fixedMenu";
+	public static final String POWERTYPE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addPowertypeStereotype.fixedMenu";
+
+	public static final String HISTORICAL_ROLE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addHistoricalRoleStereotype.fixedMenu";
+	public static final String EVENT_FIXEDMENU = "it.unibz.inf.ontouml.vp.addEventStereotype.fixedMenu";
+
+	public static final String ENUMERATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addEnumerationStereotype.fixedMenu";
+	public static final String DATATYPE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addDatatypeStereotype.fixedMenu";
+
+	public static final String SUBKIND_FIXEDMENU = "it.unibz.inf.ontouml.vp.addSubkindStereotype.fixedMenu";
+	public static final String ROLE_MIXIN_FIXEDMENU = "it.unibz.inf.ontouml.vp.addRoleMixinStereotype.fixedMenu";
+	public static final String ROLE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addRoleStereotype.fixedMenu";
+	public static final String RELATOR_FIXEDMENU = "it.unibz.inf.ontouml.vp.addRelatorStereotype.fixedMenu";
+	public static final String QUANTITY_FIXEDMENU = "it.unibz.inf.ontouml.vp.addQuantityStereotype.fixedMenu";
+	public static final String QUALITY_FIXEDMENU = "it.unibz.inf.ontouml.vp.addQualityStereotype.fixedMenu";
+	public static final String PHASE_MIXIN_FIXEDMENU = "it.unibz.inf.ontouml.vp.addPhaseMixinStereotype.fixedMenu";
+	public static final String PHASE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addPhaseStereotype.fixedMenu";
+	public static final String MODE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addModeStereotype.fixedMenu";
+	public static final String MIXIN_FIXEDMENU = "it.unibz.inf.ontouml.vp.addMixinStereotype.fixedMenu";
+	public static final String KIND_FIXEDMENU = "it.unibz.inf.ontouml.vp.addKindStereotype.fixedMenu";
+	public static final String COLLECTIVE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addCollectiveStereotype.fixedMenu";
+	public static final String CATEGORY_FIXEDMENU = "it.unibz.inf.ontouml.vp.addCategoryStereotype.fixedMenu";
+
+	// Association stereotypes (ordered as in plugin.xml)
+	public static final String INSTANTIATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addInstantiationStereotype.fixedMenu";
+
+	public static final String TERMINATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addTerminationStereotype.fixedMenu";
+	public static final String PARTICIPATIONAL_FIXEDMENU = "it.unibz.inf.ontouml.vp.addParticipationalStereotype.fixedMenu";
+	public static final String PARTICIPATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addParticipationStereotype.fixedMenu";
+	public static final String HISTORICAL_DEPENDENCE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addHistoricalDependenceStereotype.fixedMenu";
+	public static final String CREATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addCreationStereotype.fixedMenu";
+	public static final String MANIFESTATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addManifestationStereotype.fixedMenu";
+
+	public static final String SUB_QUANTITY_OF_FIXEDMENU = "it.unibz.inf.ontouml.vp.addSubQuantityStereotype.fixedMenu";
+	public static final String SUB_COLLECTION_OF_FIXEDMENU = "it.unibz.inf.ontouml.vp.addSubCollectionStereotype.fixedMenu";
+	public static final String MEMBER_OF_FIXEDMENU = "it.unibz.inf.ontouml.vp.addMemberOfStereotype.fixedMenu";
+	public static final String MEDIATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addMediationStereotype.fixedMenu";
+	public static final String MATERIAL_FIXEDMENU = "it.unibz.inf.ontouml.vp.addMaterialStereotype.fixedMenu";
+	public static final String EXTERNAL_DEPENDENCE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addExternalDependenceStereotype.fixedMenu";
+	public static final String COMPONENT_OF_FIXEDMENU = "it.unibz.inf.ontouml.vp.addComponentOfStereotype.fixedMenu";
+	public static final String COMPARATIVE_FIXEDMENU = "it.unibz.inf.ontouml.vp.addComparativeStereotype.fixedMenu";
+	public static final String CHARACTERIZATION_FIXEDMENU = "it.unibz.inf.ontouml.vp.addCharacterizationStereotype.fixedMenu";
+
+	// Attribute stereotypes (ordered as in plugin.xml)
+	public static final String END_FIXEDMENU = "it.unibz.inf.ontouml.vp.addEndStereotype.fixedMenu";
+	public static final String BEGIN_FIXEDMENU = "it.unibz.inf.ontouml.vp.addBeginStereotype.fixedMenu";
 }

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/SmartModelling.java
@@ -243,12 +243,6 @@ public class SmartModelling {
 		final ArrayList<String> sourceStereotypes = new ArrayList<String>(Arrays.asList(source.toStereotypeArray()));
 		final ArrayList<String> targetStereotypes = new ArrayList<String>(Arrays.asList(target.toStereotypeArray()));
 
-		if (sourceStereotypes.size() == 0 || targetStereotypes.size() == 0) {
-			// if any end has no stereotypes everything is allowed
-			action.setEnabled(true);
-			return;
-		}
-
 		if (sourceStereotypes.size() > 1 || targetStereotypes.size() > 1) {
 			// if any end has more than 1 stereotypes nothing is allowed
 			action.setEnabled(false);
@@ -260,11 +254,8 @@ public class SmartModelling {
 		final String targetStereotype = targetStereotypes.get(0);
 		final ArrayList<String> allowedCombinations = AssociationConstraints.allowedCombinations.get(new SimpleEntry<String, String>(sourceStereotype, targetStereotype));
 
-		if (allowedCombinations == null || !allowedCombinations.contains(action.getActionId())) {
+		if (allowedCombinations == null || !allowedCombinations.contains(action.getActionId()))
 			action.setEnabled(false);
-		} else {
-			action.setEnabled(true);
-		}
 
 		return;
 	}
@@ -273,8 +264,6 @@ public class SmartModelling {
 
 		final ISimpleRelationship[] relationshipsTo = _class.toToRelationshipArray();
 		final ISimpleRelationship[] relationshipsFrom = _class.toFromRelationshipArray();
-		
-		action.setEnabled(true);
 
 		for (int i = 0; relationshipsTo != null && i < relationshipsTo.length; i++) {
 			final ISimpleRelationship relationshipTo = relationshipsTo[i];

--- a/src/main/java/it/unibz/inf/ontouml/vp/utils/ViewUtils.java
+++ b/src/main/java/it/unibz/inf/ontouml/vp/utils/ViewUtils.java
@@ -1,6 +1,5 @@
 package it.unibz.inf.ontouml.vp.utils;
 
-import java.awt.Color;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -13,17 +12,12 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JList;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
-import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;


### PR DESCRIPTION
Added feature to apply the same stereotype to all selected objects.

How does it work?
- Select objects in the diagram
If all objects selected are the same apply the same selected stereotype to all of them.
If not apply only to the object that opened the context menu.